### PR TITLE
Remove CancellationToken support on all requests

### DIFF
--- a/src/WebApplication.Tests/TimelineServiceTests.cs
+++ b/src/WebApplication.Tests/TimelineServiceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore;
@@ -50,7 +49,7 @@ namespace WebApplication.Tests
             await using (var dbContext = new DatabaseContext(options))
             {
                 var service = CreateTimelineService(dbContext);
-                var messages = await service.GetMessagesForAnonymousUser(30, false, CancellationToken.None);
+                var messages = await service.GetMessagesForAnonymousUser(30, false);
                 
                 Assert.Equal(2, messages.Count);
             }
@@ -78,7 +77,7 @@ namespace WebApplication.Tests
             await using (var dbContext = new DatabaseContext(options))
             {
                 var service = CreateTimelineService(dbContext);
-                var messages = await service.GetMessagesForAnonymousUser(30, false, CancellationToken.None);
+                var messages = await service.GetMessagesForAnonymousUser(30, false);
                 
                 Assert.Equal(2, messages.Count);
             }
@@ -109,8 +108,8 @@ namespace WebApplication.Tests
                 var userService = CreateUserService(dbContext);
                 var service = CreateTimelineService(dbContext, userService);
 
-                var user = await userService.GetUserFromUsername("a", CancellationToken.None);
-                var messages = await service.GetMessagesForUser(user.Username, 30, false, CancellationToken.None);
+                var user = await userService.GetUserFromUsername("a");
+                var messages = await service.GetMessagesForUser(user.Username, 30, false);
                 
                 Assert.Equal(2, messages.Count);
             }
@@ -142,8 +141,8 @@ namespace WebApplication.Tests
                 var userService = CreateUserService(dbContext);
                 var service = CreateTimelineService(dbContext, userService);
 
-                var user = await userService.GetUserFromUsername("a", CancellationToken.None);
-                var messages = await service.GetMessagesForUser(user.Username, 30, false, CancellationToken.None);
+                var user = await userService.GetUserFromUsername("a");
+                var messages = await service.GetMessagesForUser(user.Username, 30, false);
                 
                 Assert.Equal(2, messages.Count);
             }
@@ -174,7 +173,7 @@ namespace WebApplication.Tests
             await using (var dbContext = new DatabaseContext(options))
             {
                 var service = CreateTimelineService(dbContext);
-                var messages = await service.GetFollowerMessagesForUser("b", 30, CancellationToken.None);
+                var messages = await service.GetFollowerMessagesForUser("b", 30);
                 
                 Assert.Equal(2, messages.Count);
             }
@@ -191,7 +190,7 @@ namespace WebApplication.Tests
                 await using (var dbContext = new DatabaseContext(options))
                 {
                     var service = CreateTimelineService(dbContext);
-                    var messages = await service.GetFollowerMessagesForUser("b", 30, CancellationToken.None);
+                    var messages = await service.GetFollowerMessagesForUser("b", 30);
                 
                     Assert.Empty(messages);
                 }
@@ -223,7 +222,7 @@ namespace WebApplication.Tests
             await using (var dbContext = new DatabaseContext(options))
             {
                 var service = CreateTimelineService(dbContext);
-                var messages = await service.GetFollowerMessagesForUser(2, 30, CancellationToken.None);
+                var messages = await service.GetFollowerMessagesForUser(2, 30);
                 
                 Assert.Equal(2, messages.Count);
             }
@@ -251,7 +250,7 @@ namespace WebApplication.Tests
                     Content = "123"
                 };
 
-                await service.CreateMessage(model, "a", CancellationToken.None);
+                await service.CreateMessage(model, "a");
             }
 
             await using (var dbContext = new DatabaseContext(options))
@@ -278,7 +277,7 @@ namespace WebApplication.Tests
                 };
 
                 await Assert.ThrowsAsync<UnknownUserException>(async () => {
-                    await service.CreateMessage(model, "a", CancellationToken.None);
+                    await service.CreateMessage(model, "a");
                 });
             }
         }
@@ -305,7 +304,7 @@ namespace WebApplication.Tests
                     Content = "123"
                 };
 
-                await service.CreateMessage(model, 1, CancellationToken.None);
+                await service.CreateMessage(model, 1);
             }
 
             await using (var dbContext = new DatabaseContext(options))
@@ -335,7 +334,7 @@ namespace WebApplication.Tests
             {
                 var service = CreateTimelineService(dbContext);
 
-                await service.AddFlagToMessage(1, CancellationToken.None);
+                await service.AddFlagToMessage(1);
             }
             
             await using (var dbContext = new DatabaseContext(options))
@@ -359,7 +358,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateTimelineService(dbContext);
 
-                    await service.AddFlagToMessage(1, CancellationToken.None);
+                    await service.AddFlagToMessage(1);
                 }
             });
         }
@@ -383,7 +382,7 @@ namespace WebApplication.Tests
             {
                 var service = CreateTimelineService(dbContext);
 
-                await service.RemoveFlagFromMessage(1, CancellationToken.None);
+                await service.RemoveFlagFromMessage(1);
             }
             
             await using (var dbContext = new DatabaseContext(options))
@@ -407,7 +406,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateTimelineService(dbContext);
 
-                    await service.RemoveFlagFromMessage(1, CancellationToken.None);
+                    await service.RemoveFlagFromMessage(1);
                 }
             });
         }

--- a/src/WebApplication.Tests/UserServiceTests.cs
+++ b/src/WebApplication.Tests/UserServiceTests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore;
@@ -36,7 +34,7 @@ namespace WebApplication.Tests
                 var service = CreateUserService(dbContext);
                 var model = new RegisterModel { Username = "a", Email = "a@a.a", Pwd = "a" };
 
-                await service.CreateUser(model, CancellationToken.None);
+                await service.CreateUser(model);
                 dbContext.SaveChanges();
             }
 
@@ -74,7 +72,7 @@ namespace WebApplication.Tests
                     var service = CreateUserService(dbContext);
                     var model = new RegisterModel { Username = "a", Email = "a@a.a", Pwd = "a" };
 
-                    await service.CreateUser(model, CancellationToken.None);
+                    await service.CreateUser(model);
                 });
             }
         }
@@ -99,7 +97,7 @@ namespace WebApplication.Tests
                     var service = CreateUserService(dbContext);
                     var model = new RegisterModel { Username = "a", Email = "a@a.a", Pwd = "a" };
 
-                    await service.CreateUser(model, CancellationToken.None);
+                    await service.CreateUser(model);
                 });
             }
         }
@@ -123,7 +121,7 @@ namespace WebApplication.Tests
             await using (var dbContext = new DatabaseContext(options))
             {
                 var service = CreateUserService(dbContext);
-                var user = await service.GetUserFromUsername("b", CancellationToken.None);
+                var user = await service.GetUserFromUsername("b");
                 
                 Assert.NotNull(user);
                 Assert.Equal("b", user.Username);
@@ -143,7 +141,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
                     
-                    await service.GetUserFromUsername("b", CancellationToken.None);
+                    await service.GetUserFromUsername("b");
                 });
             }
         }
@@ -159,7 +157,7 @@ namespace WebApplication.Tests
             {
                 var service = CreateUserService(dbContext);
 
-                var isFollowing = await service.IsUserFollowing(2, "a", CancellationToken.None);
+                var isFollowing = await service.IsUserFollowing(2, "a");
                 
                 Assert.False(isFollowing);
             }
@@ -188,7 +186,7 @@ namespace WebApplication.Tests
             await using (var dbContext = new DatabaseContext(options))
             {
                 var service = CreateUserService(dbContext);
-                var result = await service.GetUserFollowers("a", 5, CancellationToken.None);
+                var result = await service.GetUserFollowers("a", 5);
                 
                 Assert.Equal(2, result.Count);
             }
@@ -217,7 +215,7 @@ namespace WebApplication.Tests
             await using (var dbContext = new DatabaseContext(options))
             {
                 var service = CreateUserService(dbContext);
-                var result = await service.GetUserFollowers("a", 5, CancellationToken.None);
+                var result = await service.GetUserFollowers("a", 5);
                 
                 Assert.Equal(2, result.Count);
             }
@@ -243,7 +241,7 @@ namespace WebApplication.Tests
             {
                 var service = CreateUserService(dbContext);
                 
-                await service.AddFollower("a", "b", CancellationToken.None);
+                await service.AddFollower("a", "b");
             }
             
             await using (var dbContext = new DatabaseContext(options))
@@ -267,7 +265,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.AddFollower("a", "b", CancellationToken.None);
+                    await service.AddFollower("a", "b");
                 });
             }
         }
@@ -291,7 +289,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.AddFollower("a", "b", CancellationToken.None);
+                    await service.AddFollower("a", "b");
                 });
             }
         }
@@ -316,7 +314,7 @@ namespace WebApplication.Tests
             {
                 var service = CreateUserService(dbContext);
                 
-                await service.AddFollower(1, "b", CancellationToken.None);
+                await service.AddFollower(1, "b");
             }
             
             await using (var dbContext = new DatabaseContext(options))
@@ -340,7 +338,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.AddFollower(1, "b", CancellationToken.None);
+                    await service.AddFollower(1, "b");
                 });
             }
         }
@@ -364,7 +362,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.AddFollower(1, "b", CancellationToken.None);
+                    await service.AddFollower(1, "b");
                 });
             }
         }
@@ -391,7 +389,7 @@ namespace WebApplication.Tests
             {
                 var service = CreateUserService(dbContext);
                 
-                await service.RemoveFollower("a", "b", CancellationToken.None);
+                await service.RemoveFollower("a", "b");
             }
             
             await using (var dbContext = new DatabaseContext(options))
@@ -415,7 +413,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.RemoveFollower("a", "b", CancellationToken.None);
+                    await service.RemoveFollower("a", "b");
                 });
             }
         }
@@ -440,7 +438,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.RemoveFollower("a", "b", CancellationToken.None);
+                    await service.RemoveFollower("a", "b");
                 });
             }
         }
@@ -467,7 +465,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.RemoveFollower("a", "b", CancellationToken.None);
+                    await service.RemoveFollower("a", "b");
                 });
             }
         }
@@ -494,7 +492,7 @@ namespace WebApplication.Tests
             {
                 var service = CreateUserService(dbContext);
                 
-                await service.RemoveFollower(2, "a", CancellationToken.None);
+                await service.RemoveFollower(2, "a");
             }
             
             await using (var dbContext = new DatabaseContext(options))
@@ -518,7 +516,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.RemoveFollower(1, "b", CancellationToken.None);
+                    await service.RemoveFollower(1, "b");
                 });
             }
         }
@@ -544,7 +542,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.RemoveFollower(1, "b", CancellationToken.None);
+                    await service.RemoveFollower(1, "b");
                 });
             }
         }
@@ -571,7 +569,7 @@ namespace WebApplication.Tests
                 {
                     var service = CreateUserService(dbContext);
 
-                    await service.RemoveFollower(1, "b", CancellationToken.None);
+                    await service.RemoveFollower(1, "b");
                 });
             }
         }

--- a/src/WebApplication/Controllers/ApiController.cs
+++ b/src/WebApplication/Controllers/ApiController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
@@ -41,9 +40,9 @@ namespace WebApplication.Controllers
         /// </summary>
         [HttpGet("latest")]
         [ProducesResponseType(typeof(List<Latest>), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetLatest(CancellationToken ct)
+        public async Task<IActionResult> GetLatest()
         {
-            var latest = await TestingUtils.GetLatest(_databaseContext, ct);
+            var latest = await TestingUtils.GetLatest(_databaseContext);
             
             return Ok(latest);
         }
@@ -54,11 +53,11 @@ namespace WebApplication.Controllers
         [HttpPost("register")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> AddUser(RegisterModel model, CancellationToken ct)    // TODO Add request model
+        public async Task<IActionResult> AddUser(RegisterModel model)
         {
             try
             {
-                await _userService.CreateUser(model, ct);
+                await _userService.CreateUser(model);
             }
             catch (CreateUserException exception)
             {
@@ -78,9 +77,9 @@ namespace WebApplication.Controllers
         /// <param name="no">The number of messages to return.</param>
         [HttpGet("msgs")]
         [ProducesResponseType(typeof(List<MessageResponse>), StatusCodes.Status200OK)]
-        public async Task<ActionResult<List<MessageResponse>>> GetMessages([FromQuery] int no = 20, CancellationToken ct = default)
+        public async Task<ActionResult<List<MessageResponse>>> GetMessages([FromQuery] int no = 20)
         {
-            var messages = await _timelineService.GetMessagesForAnonymousUser(no, includeFlaggedMessages: false, ct);
+            var messages = await _timelineService.GetMessagesForAnonymousUser(no, includeFlaggedMessages: false);
 
             return Ok(messages.Select(msg => new MessageResponse()
             {
@@ -98,11 +97,11 @@ namespace WebApplication.Controllers
         [HttpGet("msgs/{username}")]
         [ProducesResponseType(typeof(List<MessageResponse>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult<List<MessageResponse>>> GetMessagesFromUser(string username, [FromQuery] int no = 20, CancellationToken ct = default)
+        public async Task<ActionResult<List<MessageResponse>>> GetMessagesFromUser(string username, [FromQuery] int no = 20)
         {
             try
             {
-                var messages = await _timelineService.GetMessagesForUser(username, no, includeFlaggedMessages: false, ct);
+                var messages = await _timelineService.GetMessagesForUser(username, no, includeFlaggedMessages: false);
 
                 return Ok(messages.Select(msg => new MessageResponse
                 {
@@ -124,11 +123,11 @@ namespace WebApplication.Controllers
         [HttpPost("msgs/{username}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> AddMessageToUser(string username, CreateMessageModel model, CancellationToken ct)
+        public async Task<IActionResult> AddMessageToUser(string username, CreateMessageModel model)
         {
             try
             {
-                await _timelineService.CreateMessage(model, username, ct);
+                await _timelineService.CreateMessage(model, username);
             }
             catch (UnknownUserException e)
             {
@@ -147,11 +146,11 @@ namespace WebApplication.Controllers
         [HttpGet("fllws/{username}")]
         [ProducesResponseType(typeof(FollowerCollectionResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-        public async Task<ActionResult<FollowerCollectionResponse>> GetFollowersFromUser(string username, [FromQuery] int no = 20, CancellationToken ct = default)
+        public async Task<ActionResult<FollowerCollectionResponse>> GetFollowersFromUser(string username, [FromQuery] int no = 20)
         {
             try
             {
-                var followers = await _userService.GetUserFollowers(username, no, ct);
+                var followers = await _userService.GetUserFollowers(username, no);
 
                 return Ok(new FollowerCollectionResponse
                 {
@@ -170,7 +169,7 @@ namespace WebApplication.Controllers
         [HttpPost("fllws/{username}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
-        public async Task<IActionResult> AddOrRemoveFollowerFromUser(string username, ChangeUserFollowerModel model,  CancellationToken ct)
+        public async Task<IActionResult> AddOrRemoveFollowerFromUser(string username, ChangeUserFollowerModel model)
         {
             if (string.IsNullOrWhiteSpace(model.Follow) && string.IsNullOrWhiteSpace(model.Unfollow))
             {
@@ -185,11 +184,11 @@ namespace WebApplication.Controllers
             {
                 if (!string.IsNullOrWhiteSpace(model.Follow))
                 {
-                    await _userService.AddFollower(username, model.Follow, ct);
+                    await _userService.AddFollower(username, model.Follow);
                 }
                 else
                 {
-                    await _userService.RemoveFollower(username, model.Unfollow, ct);
+                    await _userService.RemoveFollower(username, model.Unfollow);
                 }
             }
             catch (UnknownUserException e)

--- a/src/WebApplication/Controllers/AuthenticationController.cs
+++ b/src/WebApplication/Controllers/AuthenticationController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -49,9 +48,9 @@ namespace WebApplication.Controllers
         [AllowAnonymous]
         [ValidateAntiForgeryToken]
         [HttpPost("/login")]
-        public async Task<IActionResult> Login(LoginCredentialsModel credentials, CancellationToken ct)
+        public async Task<IActionResult> Login(LoginCredentialsModel credentials)
         {
-            var user = await _databaseContext.Users.FirstOrDefaultAsync(item => item.Username == credentials.Username, ct);
+            var user = await _databaseContext.Users.FirstOrDefaultAsync(item => item.Username == credentials.Username);
 
             if (user != null && Bcr.BCrypt.Verify(credentials.Password,user.Password))
             {
@@ -118,11 +117,11 @@ namespace WebApplication.Controllers
 
         [AllowAnonymous]
         [HttpPost("/register")]
-        public async Task<IActionResult> Register(RegisterModel credentials, CancellationToken ct)
+        public async Task<IActionResult> Register(RegisterModel credentials)
         {
             try
             {
-                await _service.CreateUser(credentials, ct);
+                await _service.CreateUser(credentials);
                 
                 _logger.LogInformation($"Successfully registered user with username: {credentials.Username}.");
             }

--- a/src/WebApplication/Controllers/TimelineController.cs
+++ b/src/WebApplication/Controllers/TimelineController.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 
@@ -33,11 +32,11 @@ namespace WebApplication.Controllers
         }
 
         [HttpGet("/")]
-        public async Task<IActionResult> Timeline(CancellationToken ct)
+        public async Task<IActionResult> Timeline()
         {
             ViewData["title"] = "Timeline";
 
-            var messages = await _timelineService.GetFollowerMessagesForUser(User.GetUserID(), ResultsPerPage, ct);
+            var messages = await _timelineService.GetFollowerMessagesForUser(User.GetUserID(), ResultsPerPage);
             
             var mapped = messages.Select(message => new TimelineMessageVM(
                 message.ID,
@@ -65,13 +64,13 @@ namespace WebApplication.Controllers
 
         [AllowAnonymous]
         [HttpGet("/public")]
-        public async Task<IActionResult> PublicTimeline(CancellationToken ct)
+        public async Task<IActionResult> PublicTimeline()
         {
             ViewData["title"] = "Public Timeline";
 
             var includeFlaggedMessages = User.IsInRole(AuthRoles.Administrator);
             
-            var messages = await _timelineService.GetMessagesForAnonymousUser(ResultsPerPage, includeFlaggedMessages, ct);
+            var messages = await _timelineService.GetMessagesForAnonymousUser(ResultsPerPage, includeFlaggedMessages);
 
             var mapped = messages.Select(message => new TimelineMessageVM(
                 message.ID,
@@ -90,11 +89,11 @@ namespace WebApplication.Controllers
         }
 
         [HttpGet("/{username}")]
-        public async Task<IActionResult> UserTimeline(string username, CancellationToken ct)
+        public async Task<IActionResult> UserTimeline(string username)
         {
             try
             {
-                var author = await _userService.GetUserFromUsername(username, ct);
+                var author = await _userService.GetUserFromUsername(username);
 
                 if (author == null)
                 {
@@ -102,8 +101,8 @@ namespace WebApplication.Controllers
                 }
                 
                 var includeFlaggedMessages = User.IsInRole(AuthRoles.Administrator);
-                var messages = await _timelineService.GetMessagesForUser(author.Username, ResultsPerPage, includeFlaggedMessages, ct);
-                var isUserFollowing = await _userService.IsUserFollowing(User.GetUserID(), username, ct);
+                var messages = await _timelineService.GetMessagesForUser(author.Username, ResultsPerPage, includeFlaggedMessages);
+                var isUserFollowing = await _userService.IsUserFollowing(User.GetUserID(), username);
             
                 var mapped = messages.Select(message => new TimelineMessageVM(
                     message.ID,
@@ -137,11 +136,11 @@ namespace WebApplication.Controllers
         }
 
         [HttpGet("/{username}/follow")]
-        public async Task<IActionResult> AddFollow(string username, CancellationToken ct)
+        public async Task<IActionResult> AddFollow(string username)
         {
             try
             {
-                await _userService.AddFollower(User.GetUserID(), username, ct);
+                await _userService.AddFollower(User.GetUserID(), username);
             }
             catch (UnknownUserException e)
             {
@@ -156,11 +155,11 @@ namespace WebApplication.Controllers
             return RedirectToAction(nameof(Timeline));
         }
         [HttpGet("/{username}/unfollow")]
-        public async Task<IActionResult> AddUnfollow(string username, CancellationToken ct)
+        public async Task<IActionResult> AddUnfollow(string username)
         {
             try
             {
-                await _userService.RemoveFollower(User.GetUserID(), username, ct);
+                await _userService.RemoveFollower(User.GetUserID(), username);
             }
             catch (UnknownUserException e)
             {
@@ -177,11 +176,11 @@ namespace WebApplication.Controllers
 
         [ValidateAntiForgeryToken]
         [HttpPost("/add_message")]
-        public async Task<IActionResult> AddMessage(CreateMessageModel model, CancellationToken ct)
+        public async Task<IActionResult> AddMessage(CreateMessageModel model)
         {
             try
             {
-                await _timelineService.CreateMessage(model, User.GetUserID(), ct);
+                await _timelineService.CreateMessage(model, User.GetUserID());
             }
             catch (UnknownUserException e)
             {
@@ -199,7 +198,7 @@ namespace WebApplication.Controllers
         [HttpPost("flag/{id:int}")]
         [ValidateAntiForgeryToken]
         [Authorize(Policy = AuthPolicies.Administrator)]
-        public async Task<IActionResult> AddFlagToMessage(int id, CancellationToken ct)
+        public async Task<IActionResult> AddFlagToMessage(int id)
         {
             if (id < 1)
             {
@@ -208,7 +207,7 @@ namespace WebApplication.Controllers
             
             try
             {
-                await _timelineService.AddFlagToMessage(id, ct);
+                await _timelineService.AddFlagToMessage(id);
             }
             catch (UnknownMessageException exception)
             {
@@ -228,7 +227,7 @@ namespace WebApplication.Controllers
         [HttpPost("unflag/{id:int}")]
         [ValidateAntiForgeryToken]
         [Authorize(Policy = AuthPolicies.Administrator)]
-        public async Task<IActionResult> RemoveFlagFromMessage(int id, CancellationToken ct)
+        public async Task<IActionResult> RemoveFlagFromMessage(int id)
         {
             if (id < 1)
             {
@@ -237,7 +236,7 @@ namespace WebApplication.Controllers
             
             try
             {
-                await _timelineService.RemoveFlagFromMessage(id, ct);
+                await _timelineService.RemoveFlagFromMessage(id);
             }
             catch (UnknownMessageException exception)
             {

--- a/src/WebApplication/Helpers/TestingUtils.cs
+++ b/src/WebApplication/Helpers/TestingUtils.cs
@@ -2,7 +2,6 @@ using System;
 
 using Microsoft.EntityFrameworkCore;
 using WebApplication.Entities;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -24,11 +23,11 @@ namespace WebApplication.Helpers
             _database = database ?? throw new ArgumentNullException(nameof(database));
         }
 
-        public async Task SetLatest(int val, CancellationToken ct)
+        public async Task SetLatest(int val)
         {
             try 
             {
-                var result = await _database.Latests.SingleOrDefaultAsync(l => l.id == 1, ct);
+                var result = await _database.Latests.SingleOrDefaultAsync(l => l.id == 1);
 
                 if (result == null)
                 { 
@@ -50,9 +49,9 @@ namespace WebApplication.Helpers
             }
         }
         
-        public static async Task<Latest> GetLatest(DatabaseContext databaseContext, CancellationToken ct)
+        public static async Task<Latest> GetLatest(DatabaseContext databaseContext)
         {
-            var result = await databaseContext.Latests.SingleOrDefaultAsync(l => l.id == 1, ct);
+            var result = await databaseContext.Latests.SingleOrDefaultAsync(l => l.id == 1);
 
             return result;
         }

--- a/src/WebApplication/Program.cs
+++ b/src/WebApplication/Program.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using Bcr = BCrypt.Net;
 
 using WebApplication.Entities;
-using WebApplication.Helpers;
 
 namespace WebApplication
 {

--- a/src/WebApplication/Startup.cs
+++ b/src/WebApplication/Startup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using Elasticsearch.Net;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -28,7 +27,6 @@ namespace WebApplication
     public class Startup
     {
         private IConfiguration Configuration;
-        
         
         public Startup(IConfiguration configuration)
         {
@@ -148,7 +146,7 @@ namespace WebApplication
 
                 if(context.Request.Query.TryGetValue("latest", out var testString) && int.TryParse(testString, out var latest))
                 {
-                    await utils.SetLatest(latest, context.RequestAborted);
+                    await utils.SetLatest(latest);
                 }
                 
                 await next.Invoke();


### PR DESCRIPTION
This should remove any possibility for requests made against the API to be cancelled. If the client closes the connection the operation continues as if nothing happened.

We could in theory keep these on idempotent operations (i.e., fetching public messages), but I think we are getting too many exceptions on Sentry to distinguish the actual errors from these "fillers" that I don't want to take any chances.